### PR TITLE
Added support of CSV jtl with header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target/
 /.project
 /.classpath
 /.settings
+
+.idea/

--- a/build.properties
+++ b/build.properties
@@ -1,2 +1,3 @@
 # the JMeter JTL file to process
 jmeter.jtl.file=callcenter.jtl
+jmeter.jtl.has_header=false

--- a/build.xml
+++ b/build.xml
@@ -50,7 +50,8 @@
       <java classname="org.apache.jmeter.extra.report.sla.Main" classpathref="project.class.path">
         <arg value="${project.build.directory}/report-csv-success.html"/>        
         <arg value="${basedir}/src/test/data/success.csv"/>
-        <sysproperty key="jmeter.something" value="report-csv-success"/>        
+        <sysproperty key="jmeter.something" value="report-csv-success"/> 		
+		<sysproperty key="jmeter.jtl.has_header" value="${jmeter.jtl.has_header}"/>		
       </java>        
   </target>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>at.it20one.service</groupId>
     <artifactId>jmeter-sla-report</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>JMeter Report</name>
     <inceptionYear>2011</inceptionYear>
     <description>A fast JMeter reporing task</description>

--- a/src/java/org/apache/jmeter/extra/report/sla/stax/CsvParser.java
+++ b/src/java/org/apache/jmeter/extra/report/sla/stax/CsvParser.java
@@ -17,22 +17,26 @@
  */
 package org.apache.jmeter.extra.report.sla.stax;
 
+import org.apache.jmeter.extra.report.sla.JMeterReportModel;
+import org.apache.jmeter.extra.report.sla.parser.CSVSampleParser;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 
-import org.apache.jmeter.extra.report.sla.JMeterReportModel;
-import org.apache.jmeter.extra.report.sla.parser.CSVSampleParser;
-
 public class CsvParser {
 
+    private static final String JTL_HAS_HEADER_PROPERTY = "jmeter.jtl.has_header";
+
     private final CSVSampleParser parser;
+    private boolean hasHeader;
 
     public CsvParser(JMeterReportModel model) {
     	parser = new CSVSampleParser(model);
 	}
     public void parseCsv(Reader fis) throws IOException {
         BufferedReader in = new BufferedReader(fis);
+        hasHeader = Boolean.valueOf(System.getProperty(JTL_HAS_HEADER_PROPERTY));
         try {
             parseLines(in);
         } finally {
@@ -42,6 +46,10 @@ public class CsvParser {
 
     private void parseLines(BufferedReader in) throws IOException {
         String line = null;
+        if (hasHeader) {
+            line = in.readLine();
+            parser.parseHeader(line);
+        }
         while ((line = in.readLine()) != null) {
             parser.parse(line);
         }


### PR DESCRIPTION
JMeter test result file (JTL) when in CSV format by default contains header. jmeter-sla-report at the moment doesn't support CSV JTL file to have header. To avoid additional processing on JMeter result file I've added support of CSV JTL files WITH header
